### PR TITLE
Fail on name conflicts by default

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -23,7 +23,6 @@ A Clarity [service](https://docs.clarity.st/concepts/services.html).
 ### Optional
 
 - `slug` (String) A slug for this service.
-- `unique` (Boolean) Enforce a unique name for the service.
 
 ### Read-Only
 

--- a/internal/clarity/service.go
+++ b/internal/clarity/service.go
@@ -80,6 +80,21 @@ func (config *Client) DeleteService(serviceSlug string) error {
 	return nil
 }
 
+func (config *Client) LoadService(slug string) (*Service, error) {
+	rsp, err := config.ListServices()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, service := range rsp.Services {
+		if service.Slug == slug {
+			return &service, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (config *Client) ListServices() (*ServicesListResponse, error) {
 	statusCode, output, err := config.do(http.MethodGet, "services", nil)
 	if err != nil {

--- a/internal/clarity_provider.go
+++ b/internal/clarity_provider.go
@@ -149,9 +149,20 @@ func providerCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("Must specific exactly one of 'aws' or 'webhook'")
 	}
 
+	providers, err := client.LoadProviders()
+	if err != nil {
+		return diag.Errorf("loading provider to confirm uniqueness: %v", err)
+	}
+
+	for _, p := range providers {
+		if p.Name == name {
+			return diag.Errorf("Conflict. A provider with the name '%s' already exists.", name)
+		}
+	}
+
 	provider, err := client.CreateProvider(name, info)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("creating provider: %v", err)
 	}
 
 	d.SetId(provider.Slug)

--- a/internal/resource.go
+++ b/internal/resource.go
@@ -137,6 +137,20 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 	functionName := lambda["function_name"].(string)
 	alias := lambda["alias"].(string)
 
+	// Validate
+	service, err := api.LoadService(serviceSlug)
+	if err != nil {
+		return diag.Errorf("loading service '%s' for validation: %v", serviceSlug, err)
+	}
+	if service == nil {
+		return diag.Errorf("Unable to find service with slug '%s'", serviceSlug)
+	}
+	for _, r := range service.Resources {
+		if r.Name == name {
+			return diag.Errorf("Conflict. Resource with the name '%s' already exists on the specified service", name)
+		}
+	}
+
 	internal, err := api.CreateResource(serviceSlug, clarity.CreateResourceRequest{
 		Name:        name,
 		Provider:    providerSlug,


### PR DESCRIPTION
cc @jefffroman

Should resolve #4 

## Provider conflict

```
  # clarity_provider.other will be created
  + resource "clarity_provider" "other" {
      + id   = (known after apply)
      + name = "test provider"
      + slug = (known after apply)

      + aws {
          + account_id = "993614041743"
          + region     = "us-east-1"
          + role       = "clarity-provider-us-east-1-staging-environment"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
clarity_provider.other: Creating...
╷
│ Error: Conflict. A provider with the name 'test provider' already exists.
│
│   with clarity_provider.other,
│   on main.tf line 23, in resource "clarity_provider" "other":
│   23: resource "clarity_provider" "other" {
│
╵
```


## Service conflict

```
Terraform will perform the following actions:

  # clarity_service.other will be created
  + resource "clarity_service" "other" {
      + id            = (known after apply)
      + name          = "terraform resource"
      + provider_slug = "test-provider"
      + slug          = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
clarity_service.other: Creating...
╷
│ Error: Conflict. A service with the name 'terraform resource' already exissts.
│
│   with clarity_service.other,
│   on main.tf line 28, in resource "clarity_service" "other":
│   28: resource "clarity_service" "other" {
│
╵
```


## Resource conflict

```
  # clarity_resource.other will be created
  + resource "clarity_resource" "other" {
      + id            = (known after apply)
      + name          = "dev"
      + provider_slug = "test-provider"
      + service_slug  = "terraform-resource"
      + slug          = (known after apply)

      + lambda {
          + alias         = "clarity"
          + function_name = "terraform-test"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
clarity_resource.other: Creating...
╷
│ Error: Conflict. Resource with the name 'dev' already exists on the specified service
│
│   with clarity_resource.other,
│   on main.tf line 45, in resource "clarity_resource" "other":
│   45: resource "clarity_resource" "other" {
│
╵
```
